### PR TITLE
Syntax fix in export query

### DIFF
--- a/maintenance/script/database-dumps/list-words.php
+++ b/maintenance/script/database-dumps/list-words.php
@@ -6,7 +6,7 @@ require_once(dirname(__FILE__) . "/../../../api/core.php");
 set_error_handler('core::exceptions_error_handler');
 core::loadClass("database");
 
-$query = "SELECT spelling_t_style FROM sm_spelling` WHERE 1 ORDER BY spelling_sortkey_sm;";
+$query = "SELECT spelling_t_style FROM sm_spelling WHERE 1 ORDER BY spelling_sortkey_sm;";
 $res = database::retrieve($query);
 while($row = database::get_row($res)) {
 	echo $row['spelling_t_style'] . "\n";


### PR DESCRIPTION
Strangely does not break on Debian container.

```
database::doQuery(): exception 'PDOException' with message 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '` WHERE 1 ORDER BY spelling_sortkey_sm' at line 1' in [...]/api/util/database.php:65
Stack trace:
#0 [...]/api/util/database.php(65): PDOStatement->execute(Array)
#1 [...]/api/util/database.php(38): database::doQuery('SELECT spelling...', Array)
#2 [...]/maintenance/script/database-dumps/list-words.php(10): database::retrieve('SELECT spelling...')
#3 {main}
```